### PR TITLE
OS X Recovery Message for Full Disk Encryption pre-boot screen

### DIFF
--- a/manifests/recovery_message.pp
+++ b/manifests/recovery_message.pp
@@ -7,13 +7,39 @@ define osx::recovery_message(
   $ensure = 'present',
   $value  = $name,
 ) {
+  $kextdir     = '/System/Library/Extensions'
+  $eficachedir = '/System/Library/Caches/com.apple.corestorage/EFILoginLocalizations'
+
+  # The CoreStorage kext cache needs to be updated so the recovery message
+  # is displayed on the FDE pre-boot screen.
+  #
+  # The CS cache can be updated directly by touching $eficachedir, if it exists.
+  # Otherwise you will need to touch $kextdir to generate it.
+  exec { 'Refresh system kext cache':
+      command     => "/usr/bin/touch ${kextdir}",
+      creates     => $eficachedir,
+      refreshonly => true,
+      user        => root
+  }
+
+  exec { 'Refresh CoreStorage EFI Cache':
+      command     => "/usr/bin/touch ${eficachedir}",
+      onlyif      => "test -d ${eficachedir}",
+      refreshonly => true,
+      user        => root
+  }
+
   if $ensure == 'present' {
     if $value != undef {
       property_list_key { 'Set OS X Recovery Message':
         ensure => present,
         path   => '/Library/Preferences/com.apple.loginwindow.plist',
         key    => 'LoginwindowText',
-        value  => $value
+        value  => $value,
+        notify => [
+          Exec['Refresh system kext cache'],
+          Exec['Refresh CoreStorage EFI Cache']
+        ]
       }
 
       exec { 'Set OS X Recovery Message NVRAM Variable':
@@ -28,7 +54,11 @@ define osx::recovery_message(
     property_list_key { 'Remove OS X Recovery Message':
       ensure => absent,
       path   => '/Library/Preferences/com.apple.loginwindow.plist',
-      key    => 'LoginwindowText'
+      key    => 'LoginwindowText',
+      notify => [
+        Exec['Refresh system kext cache'],
+        Exec['Refresh CoreStorage EFI Cache']
+      ]
     }
 
     exec { 'Remove OS X Recovery Message NVRAM Variable':

--- a/spec/defines/recovery_message_spec.rb
+++ b/spec/defines/recovery_message_spec.rb
@@ -1,6 +1,26 @@
 require 'spec_helper'
 
 describe 'osx::recovery_message' do
+  let(:title)       { 'foo' }
+  let(:kextdir)     { '/System/Library/Extensions' }
+  let(:eficachedir) { '/System/Library/Caches/com.apple.corestorage/EFILoginLocalizations' }
+
+  it do
+    should contain_exec('Refresh system kext cache').with({
+      :command     => "/usr/bin/touch #{kextdir}",
+      :creates     => eficachedir,
+      :refreshonly => true,
+      :user        => 'root'
+    })
+
+    should contain_exec('Refresh CoreStorage EFI Cache').with({
+      :command     => "/usr/bin/touch #{eficachedir}",
+      :onlyif      => "test -d #{eficachedir}",
+      :refreshonly => true,
+      :user        => 'root'
+    })
+  end
+
   context 'given a name' do
     let(:title) { 'If this Mac is found, please call 123-123-1234' }
 


### PR DESCRIPTION
Set the NVRAM good-samaritan-message variable so the OS X Recovery Message is also displayed on the Full Disk Encryption pre-boot screen.

This is the default behavior if set from System Preferences.
