### PR TITLE
Native type to manage Spotlight exclusions

### DIFF
--- a/lib/puppet/provider/osx_spotlight_exclude/plistbuddy.rb
+++ b/lib/puppet/provider/osx_spotlight_exclude/plistbuddy.rb
@@ -1,0 +1,52 @@
+require 'rexml/document'
+
+Puppet::Type.type(:osx_spotlight_exclude).provide(:plistbuddy) do
+  commands :plutil     => 'plutil',
+           :plistbuddy => '/usr/libexec/PlistBuddy'
+
+  FILE = '/.Spotlight-V100/VolumeConfiguration.plist'
+
+  def create
+    @property_hash = {
+      :name   => @resource[:name],
+      :ensure => :present,
+    }
+    plistbuddy '-c', "Add Exclusions: string '#{@property_hash[:name]}'", FILE
+  end
+
+  def destroy
+    plistbuddy '-c', "Delete Exclusions:#{@property_hash[:index]}", FILE
+    @property_hash.clear
+  end
+
+  def exists?
+    !(@property_hash[:ensure] == :absent or @property_hash.empty?)
+  end
+
+  def self.instances
+    xml = plutil '-convert', 'xml1', '-o', '/dev/stdout', FILE
+    doc = REXML::Document.new(xml).root
+
+    instances = []
+    index = 0
+
+    doc.elements['//key[.="Exclusions"]'].next_element.each_element('string') do |e|
+      instances << new({
+        :name     => e.text,
+        :index    => index,
+        :ensure   => :present,
+        :provider => self.name,
+      })
+      index += 1
+    end
+    instances
+  end
+
+  def self.prefetch(resources)
+    instances.each do |provider|
+      if resource = resources[provider.name.to_s]
+        resource.provider = provider
+      end
+    end
+  end
+end

--- a/lib/puppet/type/osx_spotlight_exclude.rb
+++ b/lib/puppet/type/osx_spotlight_exclude.rb
@@ -1,0 +1,39 @@
+Puppet::Type.newtype(:osx_spotlight_exclude) do
+  @doc = <<-EOF.strip
+    A type for managing directories that should be excluded from the Spotlight
+    index.
+
+    osx_spotlight_exclude { '/home/myuser/.vagrant': }
+  EOF
+
+  ensurable do
+    desc <<-EOF.strip
+      The desired state of the Spotlight exclusion.
+    EOF
+
+    newvalue(:present) do
+      provider.create
+    end
+
+    newvalue(:absent) do
+      provider.destroy
+    end
+
+    defaultto :present
+  end
+
+  newparam(:path) do
+    desc <<-EOF.strip
+      The path to exclude from Spotlight indexing.
+    EOF
+
+    isnamevar
+  end
+
+  newparam(:index) do
+    desc <<-EOF.strip
+      A read-only parameter set by Puppet. Manually specifying this value may
+      cause bad things to happen to your machine.
+    EOF
+  end
+end


### PR DESCRIPTION
As described, because grepping through the output of `defaults` is bad.
