### PR TITLE
autohide-delay is a float

### DIFF
--- a/manifests/dock/disable.pp
+++ b/manifests/dock/disable.pp
@@ -5,6 +5,7 @@ class osx::dock::disable {
   boxen::osx_defaults { 'Disable the dock':
     user   => $::boxen_user,
     key    => 'autohide-delay',
+    type   => 'float',
     domain => 'com.apple.dock',
     value  => 999999,
     notify => Exec['killall Dock'];

--- a/spec/classes/dock/disable_spec.rb
+++ b/spec/classes/dock/disable_spec.rb
@@ -9,6 +9,7 @@ describe 'osx::dock::disable' do
     should contain_boxen__osx_defaults('Disable the dock').with({
       :key    => 'autohide-delay',
       :domain => 'com.apple.dock',
+      :type   => 'float',
       :value  => 999999,
       :notify => 'Exec[killall Dock]',
       :user   => facts[:boxen_user]


### PR DESCRIPTION
This should make `include osx::dock::disable` actually work.
