### PR TITLE
osx_login_item : added user parameter

### DIFF
--- a/lib/puppet/provider/osx_login_item/osascript.rb
+++ b/lib/puppet/provider/osx_login_item/osascript.rb
@@ -54,6 +54,7 @@ private
   end
 
   def run_script(script)
-    %x{/usr/bin/osascript -e '#{script.gsub(/\n/, ' ').squeeze(' ').strip}'}
+   	sudo =  resource[:user] ? "sudo -u '#{resource[:user]}' " : ""
+    %x{#{sudo}/usr/bin/osascript -e '#{script.gsub(/\n/, ' ').squeeze(' ').strip}'}
   end
 end

--- a/lib/puppet/type/osx_login_item.rb
+++ b/lib/puppet/type/osx_login_item.rb
@@ -17,6 +17,10 @@ Puppet::Type.newtype(:osx_login_item) do
     desc "The name of the login item."
   end
 
+  newparam :user do
+      desc "The name of the target user."
+  end
+    
   newparam :path do
     desc "The path to the application to be run at login."
   end


### PR DESCRIPTION
Hi, 

The current code can add login items to the current user only. When puppet runs with its own user, it is not possible to add a login_item to a specific user. 

This commit adds sudo -u before the command if the user parameter is specified. 
## 

Nicolas
