### PR TITLE
Fix recovery_message on Mavericks

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ class { 'osx::dock::icon_size':
 ## Required Puppet Modules
 
 * boxen
-* property_list_key
 
 ## Developing
 

--- a/manifests/recovery_message.pp
+++ b/manifests/recovery_message.pp
@@ -40,9 +40,9 @@ define osx::recovery_message(
 
   if $ensure == 'present' {
     if $value != undef {
-      property_list_key { 'Set OS X Recovery Message':
+      boxen::osx_defaults { 'Set OS X Recovery Message':
         ensure => present,
-        path   => '/Library/Preferences/com.apple.loginwindow.plist',
+        domain => '/Library/Preferences/com.apple.loginwindow.plist',
         key    => 'LoginwindowText',
         value  => $value,
         notify => [
@@ -60,9 +60,9 @@ define osx::recovery_message(
       fail('Cannot set an OS X recovery message without a value')
     }
   } else {
-    property_list_key { 'Remove OS X Recovery Message':
+    boxen::osx_defaults { 'Remove OS X Recovery Message':
       ensure => absent,
-      path   => '/Library/Preferences/com.apple.loginwindow.plist',
+      domain => '/Library/Preferences/com.apple.loginwindow.plist',
       key    => 'LoginwindowText',
       notify => [
         Exec['Refresh system kext cache'],

--- a/spec/defines/recovery_message_spec.rb
+++ b/spec/defines/recovery_message_spec.rb
@@ -25,9 +25,9 @@ describe 'osx::recovery_message' do
     let(:title) { 'If this Mac is found, please call 123-123-1234' }
 
     it do
-      should contain_property_list_key('Set OS X Recovery Message').with({
+      should contain_boxen__osx_defaults('Set OS X Recovery Message').with({
         :ensure => 'present',
-        :path   => '/Library/Preferences/com.apple.loginwindow.plist',
+        :domain => '/Library/Preferences/com.apple.loginwindow.plist',
         :key    => 'LoginwindowText',
         :value  => title
       })
@@ -45,9 +45,9 @@ describe 'osx::recovery_message' do
     let(:params) { {:ensure => 'absent'} }
 
     it do
-      should contain_property_list_key('Remove OS X Recovery Message').with({
+      should contain_boxen__osx_defaults('Remove OS X Recovery Message').with({
         :ensure => 'absent',
-        :path   => '/Library/Preferences/com.apple.loginwindow.plist',
+        :domain => '/Library/Preferences/com.apple.loginwindow.plist',
         :key    => 'LoginwindowText',
       })
 

--- a/spec/fixtures/Puppetfile
+++ b/spec/fixtures/Puppetfile
@@ -1,2 +1,1 @@
 mod "boxen", "2.0.0", :github_tarball => "boxen/puppet-boxen"
-mod "property_list_key", "0.1.0",  :github_tarball => "glarizza/puppet-property_list_key"

--- a/spec/fixtures/Puppetfile.lock
+++ b/spec/fixtures/Puppetfile.lock
@@ -3,12 +3,6 @@ GITHUBTARBALL
   specs:
     boxen (2.0.0)
 
-GITHUBTARBALL
-  remote: glarizza/puppet-property_list_key
-  specs:
-    property_list_key (0.1.0)
-
 DEPENDENCIES
   boxen (= 2.0.0)
-  property_list_key (= 0.1.0)
 


### PR DESCRIPTION
Use `boxen::osx_defaults` instead of `property_list_key`.

`property_list_key` depends on RubyCocoa to work and RubyCocoa doesn't work on Ruby 2.0
