### PR TITLE
Ability to set dock magnification size

### DIFF
--- a/manifests/dock/magnification.pp
+++ b/manifests/dock/magnification.pp
@@ -1,4 +1,4 @@
-# Public: Sets dock icon magnification 
+# Public: Sets dock icon magnification
 #
 # Examples
 #


### PR DESCRIPTION
This manifest allows one to set the magnification size of the dock, if you are into that sort of thing.

The default activates magnification and magnifies icons to 128px (the largest size available).  You can specify this size with the $magnification-size var.
