### PR TITLE
Dock minimize to app icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Just `include` any of these in your manifest.
 * `osx::dock::dim_hidden_apps` - dims icons of hidden apps
 * `osx::dock::hide_indicator_lights` - remove the indicator lights below running
   apps
+* `osx::dock::minimize-to-icon` - will minimize your windows to the application icon, 
+  rather than to the right hand side of the dock.
 
 ### Finder Settings
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Just `include` any of these in your manifest.
 * `osx::dock::dim_hidden_apps` - dims icons of hidden apps
 * `osx::dock::hide_indicator_lights` - remove the indicator lights below running
   apps
-* `osx::dock::minimize-to-icon` - will minimize your windows to the application icon, 
+* `osx::dock::minimize_to_icon` - will minimize your windows to the application icon, 
   rather than to the right hand side of the dock.
 
 ### Finder Settings

--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ Just `include` any of these in your manifest.
 * `osx::dock::dim_hidden_apps` - dims icons of hidden apps
 * `osx::dock::hide_indicator_lights` - remove the indicator lights below running
   apps
-* `osx::dock::minimize_to_icon` - will minimize your windows to the application icon, 
-  rather than to the right hand side of the dock.
 
 ### Finder Settings
 

--- a/manifests/dock/minimize_to_icon.pp
+++ b/manifests/dock/minimize_to_icon.pp
@@ -16,7 +16,7 @@ class osx::dock::minimize_to_icon ($minimize_to_icon = true){
     domain => 'com.apple.dock',
     key    => 'minimize_to_icon',
     type   => 'bool',
-    value  => $minimize-to-icon,
+    value  => $minimize_to_icon,
     user   => $::boxen_user,
     notify => Exec['killall Dock'];
   }

--- a/manifests/dock/minimize_to_icon.pp
+++ b/manifests/dock/minimize_to_icon.pp
@@ -1,0 +1,24 @@
+# Public: Sets whether widowns are minimized to the application icon,
+# or to the right hand side of the dock.
+#
+# Examples
+#
+#   # Set minimize-to-icon to true
+#   include osx::dock::minimize-to-icon
+#
+#
+
+
+class osx::dock::minimize-to-icon ($minimize-to-icon = 'true'){
+  include osx::dock
+
+  boxen::osx_defaults { 'minimize-to-icon':
+    domain => 'com.apple.dock',
+    key    => 'minimize-to-icon',
+    type   => 'boolean',
+    value  => '$minimize-to-icon',
+    user   => $::boxen_user,
+    notify => Exec['killall Dock'];
+  }
+
+}

--- a/manifests/dock/minimize_to_icon.pp
+++ b/manifests/dock/minimize_to_icon.pp
@@ -3,18 +3,18 @@
 #
 # Examples
 #
-#   # Set minimize-to-icon to true
-#   include osx::dock::minimize-to-icon
+#   # Set minimize_to_icon to true
+#   include osx::dock::minimize_to_icon
 #
 #
 
 
-class osx::dock::minimize-to-icon ($minimize-to-icon = true){
+class osx::dock::minimize_to_icon ($minimize_to_icon = true){
   include osx::dock
 
-  boxen::osx_defaults { 'minimize-to-icon':
+  boxen::osx_defaults { 'minimize_to_icon':
     domain => 'com.apple.dock',
-    key    => 'minimize-to-icon',
+    key    => 'minimize_to_icon',
     type   => 'bool',
     value  => $minimize-to-icon,
     user   => $::boxen_user,

--- a/manifests/dock/minimize_to_icon.pp
+++ b/manifests/dock/minimize_to_icon.pp
@@ -1,5 +1,5 @@
-# Public: Sets whether widowns are minimized to the application icon,
-# or to the right hand side of the dock.
+# Public: Minimize your windows to the application icon, rather than to the
+# right hand side of the dock
 #
 # Examples
 #

--- a/manifests/dock/minimize_to_icon.pp
+++ b/manifests/dock/minimize_to_icon.pp
@@ -9,14 +9,14 @@
 #
 
 
-class osx::dock::minimize-to-icon ($minimize-to-icon = 'true'){
+class osx::dock::minimize-to-icon ($minimize-to-icon = true){
   include osx::dock
 
   boxen::osx_defaults { 'minimize-to-icon':
     domain => 'com.apple.dock',
     key    => 'minimize-to-icon',
-    type   => 'boolean',
-    value  => '$minimize-to-icon',
+    type   => 'bool',
+    value  => $minimize-to-icon,
     user   => $::boxen_user,
     notify => Exec['killall Dock'];
   }


### PR DESCRIPTION
This manifest will allow windows to be minimized to the application icon, and not to the right hand side of the dock.
