### PR TITLE
Manage interface sound effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,18 @@ class { 'osx::dock::pin_position':
 }
 ```
 
+`osx::sound::interface_sound_effects` - enable interface sound effects (true, false)
+
+```puppet
+# Set the default value (true)
+include osx::sound::interface_sound_effects
+
+# ... or set your own
+class { 'osx::sound::interface_sound_effects':
+  enable => false
+}
+```
+
 ## Required Puppet Modules
 
 * boxen

--- a/manifests/sound/interface_sound_effects.pp
+++ b/manifests/sound/interface_sound_effects.pp
@@ -1,0 +1,17 @@
+# Public: Manages interface sound effects
+class osx::sound::interface_sound_effects (
+  $enable = true
+) {
+
+  $value = $enable ? {
+    false   => 0,
+    default => 1
+  }
+
+  boxen::osx_defaults { 'Manage interface sound effects':
+    user      => $::boxen_user,
+    key       => 'com.apple.sound.uiaudio.enabled',
+    domain    => 'com.apple.systemsound',
+    value     => $value,
+  }
+}

--- a/spec/classes/sound/interface_sound_effects_spec.rb
+++ b/spec/classes/sound/interface_sound_effects_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe 'osx::sound::interface_sound_effects' do
+  let(:facts) { {:boxen_user => 'ilikebees'} }
+
+  describe 'default' do
+    it do
+      should contain_boxen__osx_defaults('Manage interface sound effects').with({
+        :key    => 'com.apple.sound.uiaudio.enabled',
+        :domain => 'com.apple.systemsound',
+        :value  => 1,
+        :user   => facts[:boxen_user]
+      })
+    end
+  end
+
+  describe 'enable' do
+    let(:params) { {:enable => true} }
+    it do
+      should contain_boxen__osx_defaults('Manage interface sound effects').with({
+        :key    => 'com.apple.sound.uiaudio.enabled',
+        :domain => 'com.apple.systemsound',
+        :value  => 1,
+        :user   => facts[:boxen_user]
+      })
+    end
+  end
+
+  describe 'disable' do
+    let(:params) { {:enable => false} }
+    it do
+      should contain_boxen__osx_defaults('Manage interface sound effects').with({
+        :key    => 'com.apple.sound.uiaudio.enabled',
+        :domain => 'com.apple.systemsound',
+        :value  => 0,
+        :user   => facts[:boxen_user]
+      })
+    end
+  end
+end


### PR DESCRIPTION
Adding `osx::sound::interface_sound_effects` to toggle interface sound
effects off and on.
