### PR TITLE
Add recipes for tap-to-click and opening newly mounted volumes

### DIFF
--- a/manifests/global/open_new_volumes.pp
+++ b/manifests/global/open_new_volumes.pp
@@ -1,0 +1,28 @@
+class osx::global::open_new_volumes {
+  boxen::osx_defaults { 'Auto Open New Read-Only Volumes':
+    ensure => present,
+    domain => 'com.apple.frameworks.diskimages',
+    key => 'auto-open-ro-root',
+    value => true,
+    type => bool,
+    user => $::boxen_user;
+  }
+
+  boxen::osx_defaults { 'Auto Open New Read-Write Volumes':
+    ensure => present,
+    domain => 'com.apple.frameworks.diskimages',
+    key => 'auto-open-rw-root',
+    value => true,
+    type => bool,
+    user => $::boxen_user;
+  }
+
+  boxen::osx_defaults { 'Auto Open New Removable Volumes':
+    ensure => present,
+    domain => 'com.apple.finder',
+    key => 'OpenWindowForNewRemovableDisk',
+    value => true,
+    type => bool,
+    user => $::boxen_user;
+  }
+}

--- a/manifests/global/tap_to_click.pp
+++ b/manifests/global/tap_to_click.pp
@@ -1,0 +1,19 @@
+class osx::global::tap_to_click {
+  boxen::osx_defaults { 'Tap-To-Click Bluetooth':
+    ensure => present,
+    domain => 'com.apple.driver.AppleBluetoothMultitouch.trackpad',
+    key => 'Clicking',
+    value => true,
+    type => bool,
+    user => $::boxen_user;
+  }
+
+  boxen::osx_defaults { 'Tap-To-Click Mouse':
+    ensure => present,
+    domain => 'NSGlobalDomain',
+    key => 'com.apple.mouse.tapBehavior',
+    value => 1,
+    type => int,
+    user => $::boxen_user;
+  }
+}


### PR DESCRIPTION
- tap to click
- auto-open newly mounted or inserted volumes (included DMG files)

@bleything @fromonesrc
