### PR TITLE
enabling dock magnification option

### DIFF
--- a/manifests/dock/magnification.pp
+++ b/manifests/dock/magnification.pp
@@ -1,0 +1,12 @@
+# Public: Magnify's the dock as you mouse over it.
+class osx::dock::magnification {
+  include osx::dock
+
+  boxen::osx_defaults { 'Magnifies the doc':
+    user   => $::boxen_user,
+    key    => 'magnification',
+    domain => 'com.apple.dock',
+    value  => true,
+    notify => Exec['killall Dock'];
+  }
+}

--- a/spec/classes/dock/magnification_spec.rb
+++ b/spec/classes/dock/magnification_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'osx::dock::magnification' do
+  let(:facts) { {:boxen_user => 'ilikebees'} }
+
+  it do
+    should include_class('osx::dock')
+
+    should contain_boxen__osx_defaults('Magnifies the doc').with({
+      :key    => 'magnification',
+      :domain => 'com.apple.dock',
+      :value  => true,
+      :notify => 'Exec[killall Dock]',
+      :user   => facts[:boxen_user]
+    })
+  end
+end


### PR DESCRIPTION
This enables dock icon zooming.   It's a parallel property in the com.apple.dock domain to the 'autohide' feature and the code is identical. 
