### PR TITLE
Add osx::finder::show_all_filename_extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Just `include` any of these in your manifest.
 * `osx::finder::unhide_library` - unsets the hidden flag on ~/Library
 * `osx::finder::show_hidden_files`
 * `osx::finder::enable_quicklook_text_selection`
+* `osx::finder::show_all_filename_extensions`
 
 ### Universal Access Settings
 

--- a/manifests/finder/show_all_filename_extensions.pp
+++ b/manifests/finder/show_all_filename_extensions.pp
@@ -1,0 +1,12 @@
+# Public: Show all filename extensions.
+class osx::finder::show_all_filename_extensions {
+  include osx::finder
+
+  boxen::osx_defaults { 'Show all filename extensions':
+    user   => $::boxen_user,
+    key    => 'AppleShowAllExtensions',
+    domain => 'com.apple.finder',
+    value  => true,
+    notify => Exec['killall Finder'];
+  }
+}

--- a/spec/classes/finder/show_all_filename_extensions_spec.rb
+++ b/spec/classes/finder/show_all_filename_extensions_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'osx::finder::show_all_filename_extensions' do
+  let(:facts) { {:boxen_user => 'ilikebees'} }
+
+  it do
+    should include_class('osx::finder')
+
+    should contain_boxen__osx_defaults('Show all filename extensions').with({
+      :key    => 'AppleShowAllExtensions',
+      :domain => 'com.apple.finder',
+      :value  => true,
+      :notify => 'Exec[killall Finder]',
+      :user   => facts[:boxen_user]
+    })
+  end
+end


### PR DESCRIPTION
Finder Preferences > Advanced > Show all filename extensions
