### PR TITLE
Add osx::finder::show_warning_before_changing_an_extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Just `include` any of these in your manifest.
 * `osx::finder::unhide_library` - unsets the hidden flag on ~/Library
 * `osx::finder::show_hidden_files`
 * `osx::finder::enable_quicklook_text_selection`
+* `osx::finder::show_warning_before_changing_an_extension`
 
 ### Universal Access Settings
 

--- a/manifests/finder/show_warning_before_changing_an_extension.pp
+++ b/manifests/finder/show_warning_before_changing_an_extension.pp
@@ -1,0 +1,12 @@
+# Public: Show warning before changing an extension.
+class osx::finder::show_warning_before_changing_an_extension {
+  include osx::finder
+
+  boxen::osx_defaults { 'Show warning before changing an extension':
+    user   => $::boxen_user,
+    key    => 'FXEnableExtensionChangeWarning',
+    domain => 'com.apple.finder',
+    value  => true,
+    notify => Exec['killall Finder'];
+  }
+}

--- a/spec/classes/finder/show_warning_before_changing_an_extension_spec.rb
+++ b/spec/classes/finder/show_warning_before_changing_an_extension_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'osx::finder::show_warning_before_changing_an_extension' do
+  let(:facts) { {:boxen_user => 'ilikebees'} }
+
+  it do
+    should include_class('osx::finder')
+
+    should contain_boxen__osx_defaults('Show warning before changing an extension').with({
+      :key    => 'FXEnableExtensionChangeWarning',
+      :domain => 'com.apple.finder',
+      :value  => true,
+      :notify => 'Exec[killall Finder]',
+      :user   => facts[:boxen_user]
+    })
+  end
+end


### PR DESCRIPTION
Finder Preferences > Advanced > Show warning before changing an extension
