### PR TITLE
Add osx::finder::disable_desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Just `include` any of these in your manifest.
 * `osx::finder::show_mounted_servers_on_desktop`
 * `osx::finder::show_removable_media_on_desktop`
 * `osx::finder::show_all_on_desktop` - does all of the above
+* `osx::finder::disable_desktop` - shows nothing on the desktop, including files in ~/Desktop
 * `osx::finder::empty_trash_securely` - enable Secure Empty Trash
 * `osx::finder::unhide_library` - unsets the hidden flag on ~/Library
 * `osx::finder::show_hidden_files`

--- a/manifests/finder/disable_desktop.pp
+++ b/manifests/finder/disable_desktop.pp
@@ -1,0 +1,12 @@
+# Public: Disable desktop
+class osx::finder::disable_desktop {
+  include osx::finder
+
+  boxen::osx_defaults { 'Disable desktop':
+    user   => $::boxen_user,
+    domain => 'com.apple.finder',
+    key    => 'CreateDesktop',
+    value  => false,
+    notify => Exec['killall Finder'];
+  }
+}

--- a/spec/classes/finder/disable_desktop_spec.rb
+++ b/spec/classes/finder/disable_desktop_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'osx::finder::disable_desktop' do
+  let(:facts) { {:boxen_user => 'ilikebees'} }
+
+  it do
+    should include_class('osx::finder')
+
+    should contain_boxen__osx_defaults('Disable desktop').with({
+      :key    => 'CreateDesktop',
+      :domain => 'com.apple.finder',
+      :value  => false,
+      :notify => 'Exec[killall Finder]',
+      :user   => facts[:boxen_user]
+    })
+  end
+end


### PR DESCRIPTION
This adds another finder option to completely disable the OS X desktop all together. When this is included you will see your normal desktop background, but no icons for anything including the contents of `~/Desktop`. I've added a spec and a line to the README as well.