### PR TITLE
include osx::dock::autohide inside osx::dock::disable

### DIFF
--- a/manifests/dock/disable.pp
+++ b/manifests/dock/disable.pp
@@ -1,6 +1,7 @@
 # Public: Disables the dock by setting a long autohide-delay
 class osx::dock::disable {
   include osx::dock
+  include osx::dock::autohide
 
   boxen::osx_defaults { 'Disable the dock':
     user   => $::boxen_user,

--- a/spec/classes/dock/disable_spec.rb
+++ b/spec/classes/dock/disable_spec.rb
@@ -6,6 +6,14 @@ describe 'osx::dock::disable' do
   it do
     should include_class('osx::dock')
 
+    should contain_boxen__osx_defaults('Automatically hide the dock').with({
+      :key    => 'autohide',
+      :domain => 'com.apple.dock',
+      :value  => true,
+      :notify => 'Exec[killall Dock]',
+      :user   => facts[:boxen_user]
+    })
+
     should contain_boxen__osx_defaults('Disable the dock').with({
       :key    => 'autohide-delay',
       :domain => 'com.apple.dock',


### PR DESCRIPTION
disable doesn't actually disable the dock unless it's also had autohide turned on. add an explicit include so this happens automatically and doesn't violate POLS.