### PR TITLE
Add a class to map capslock to no action

### DIFF
--- a/manifests/keyboard/capslock_to_no_action.pp
+++ b/manifests/keyboard/capslock_to_no_action.pp
@@ -1,0 +1,16 @@
+# Public: Remaps capslock to no action on attached keyboards.
+#
+# Example
+#
+#   include osx::keyboard::capslock_to_no_action
+#
+class osx::keyboard::capslock_to_no_action {
+  # Remap capslock to no action on all attached keyboards
+  $keyboard_ids = 'ioreg -n IOHIDKeyboard -r | grep -E \'VendorID"|ProductID\' | awk \'{ print $4 }\' | paste -s -d\'-\n\' -'
+  $check = 'xargs -I{} sh -c \'defaults -currentHost read -g "com.apple.keyboard.modifiermapping.{}-0" | grep "Dst = 2" > /dev/null\''
+  $remap = 'xargs -I{} defaults -currentHost write -g "com.apple.keyboard.modifiermapping.{}-0" -array "<dict><key>HIDKeyboardModifierMappingDst</key><integer>-1</integer><key>HIDKeyboardModifierMappingSrc</key><integer>0</integer></dict>"'
+  exec { 'Remap capslock to control on all keyboards':
+    command => "${keyboard_ids} | ${remap}",
+    unless  => "${keyboard_ids} | ${check}"
+  }
+}


### PR DESCRIPTION
This copies from the `osx::keyboard::capslock_to_control` class and provides the ability to set capslock to 'no action'.
